### PR TITLE
Update 08.md

### DIFF
--- a/08.md
+++ b/08.md
@@ -212,7 +212,7 @@ template<class... Ts> struct overloaded : Ts... { using Ts::operator()...; };
 template<class... Ts> overloaded(Ts...) -> overloaded<Ts...>;
 ```
 
-模板 `overloaded` 真应该是标准的。只有那些熟悉变参模板（[§4.3.2](04.md#432-变参模板)）和模板参数推导（[§8.1](#81-构造函数模板参数推导)）的人才会觉得它比较简单。不过，有了 `overloaded`，我就能根据变体的类型来构造出分支：
+模板 `overloaded` 真应该是标准的。只有那些熟悉变参模板（[§4.3.2](04.md#432-变参模板)）和模板参数推导（[§8.1](#81-构造函数模板参数推导)）的人才会觉得它们比较简单。不过，有了 `overloaded`，我就能根据变体的类型来构造出分支：
 
 ```cpp
 using var_t = std::variant<int, long, double, std::string>; // variant 类型


### PR DESCRIPTION
That overloaded template really ought to be standard. It is simple only to people comfortable with variadic templates (ğ4.3.2) and template argument deduction guides (ğ8.1).

虽然英文里是it，但对应中文这里应该是指“变参模板”和“模板参数推导”，所以觉得改为“它们”更合适，也不容易和前面的“模板 `overloaded` 真应该是标准的”混淆。